### PR TITLE
Update ts_anom_detection.R

### DIFF
--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -125,7 +125,7 @@ AnomalyDetectionTs = function(x, max_anoms=0.10, direction='pos', alpha=0.05, on
   
   if(gran == "day"){
     num_days_per_line <- 7
-    if(only_last == 'hr'){
+    if(!is.null(only_last) &&  only_last == 'hr'){
       only_last <- 'day'
     }
   } else {


### PR DESCRIPTION
There's currently a bug for data with daily granulraity.  If gran == day, AnomalyDetectionTs does a check:

if(only_last == 'hr')

However, only_last can also be null.  If it is, this check generates an error which keeps AnomalyDetectionTs from finishing:

Error in if (only_last == "hr") { : argument is of length zero

This patch fixes the check for only_last parameter when gran == day.