### PR TITLE
perform log scaling in add_formatted_y() instead of using coord_trans()

### DIFF
--- a/R/plot_utils.R
+++ b/R/plot_utils.R
@@ -1,12 +1,13 @@
-get_range <- function(dfs, index = 2) {
-  vrange <- range(dfs[[index]], na.rm = TRUE)
-  vmin <- vrange[1]
-  vmax <- vrange[2]
-  
+get_range <- function(dfs, index = 2, y_log = F) {
+  vals <- dfs[[index]]
+  if(y_log) vals <- vals[vals > 0]
+  vrange = range(vals, na.rm=TRUE)
+  vmin = vrange[1]
+  vmax = vrange[2]
   return(c(vmin, vmax))
 }
 
-add_formatted_y <- function(yrange, expand = TRUE, digits = 1) {
+add_formatted_y <- function(yrange, y_log = FALSE, expand = TRUE, digits = 1) {
   ymin <- yrange[1]
   ymax <- yrange[2]
   
@@ -27,7 +28,14 @@ add_formatted_y <- function(yrange, expand = TRUE, digits = 1) {
     unit <- ""
   }
   
-  return (ggplot2::scale_y_continuous(breaks=seq(ymin, ymax, length.out=6), limits=c(ymin, ymax), labels=function(x) paste(round(x/divisor, digits=digits),unit,sep="")))
+  if(y_log){
+    transform = "log10"
+  }
+  else {
+    transform = "identity"
+  }
+  
+  return (ggplot2::scale_y_continuous(breaks=seq(ymin, ymax, length.out=6), limits=c(ymin, ymax), labels=function(x) paste(round(x/divisor, digits=digits),unit,sep=""), trans = transform))
   
 }
 

--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -286,17 +286,15 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
     if(!is.null(only_last)){
       xgraph <- ggplot2::ggplot(x_subset_week, ggplot2::aes_string(x="timestamp", y="count")) + ggplot2::theme_bw() + ggplot2::theme(panel.grid.major = ggplot2::element_blank(), panel.grid.minor = ggplot2::element_blank(), text=ggplot2::element_text(size = 14))
       xgraph <- xgraph + ggplot2::geom_line(data=x_subset_week, ggplot2::aes_string(colour=color_name), alpha=alpha*.33) + ggplot2::geom_line(data=x_subset_single_day, ggplot2::aes_string(color=color_name), alpha=alpha)    
-      week_rng = get_range(x_subset_week, index=2)
-      day_rng = get_range(x_subset_single_day, index=2)
+      week_rng = get_range(x_subset_week, index=2, y_log=y_log)
+      day_rng = get_range(x_subset_single_day, index=2, y_log=y_log)
       yrange = c(min(week_rng[1],day_rng[1]), max(week_rng[2],day_rng[2]))
-      xgraph <- xgraph + add_formatted_y(yrange)
       xgraph <- add_day_labels_datetime(xgraph, breaks=breaks, start=as.POSIXlt(min(x_subset_week[[1]]), tz="UTC"), end=as.POSIXlt(max(x_subset_single_day[[1]]), tz="UTC"), days_per_line=num_days_per_line)
       xgraph <- xgraph + ggplot2::labs(x=xlabel, y=ylabel, title=plot_title)    
     }else{
       xgraph <- ggplot2::ggplot(x, ggplot2::aes_string(x="timestamp", y="count")) + ggplot2::theme_bw() + ggplot2::theme(panel.grid.major = ggplot2::element_line(colour = "gray60"), panel.grid.major.y = ggplot2::element_blank(), panel.grid.minor = ggplot2::element_blank(), text=ggplot2::element_text(size = 14))
       xgraph <- xgraph + ggplot2::geom_line(data=x, ggplot2::aes_string(colour=color_name), alpha=alpha)
-      yrange <- get_range(x, index=2)
-      xgraph <- xgraph + add_formatted_y(yrange)
+      yrange <- get_range(x, index=2, y_log=y_log)
       xgraph <- xgraph + ggplot2::scale_x_datetime(labels=function(x) ifelse(as.POSIXlt(x, tz="UTC")$hour != 0,strftime(x, format="%kh", tz="UTC"), strftime(x, format="%b %e", tz="UTC")), 
                                                   expand=c(0,0))
       xgraph <- xgraph + ggplot2::labs(x=xlabel, y=ylabel, title=plot_title)
@@ -310,10 +308,8 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
     xgraph <- xgraph + ggplot2::theme(legend.position="none") 
     
     # Use log scaling if set by user
-    if (y_log) {
-      # print("scaling y axis to log")
-      xgraph <- xgraph + ggplot2::coord_trans(ytrans = "log10")
-    }
+    xgraph <- xgraph + add_formatted_y(yrange, y_log=y_log)
+    
   }
   
   # Store expected values if set by user

--- a/R/vec_anom_detection.R
+++ b/R/vec_anom_detection.R
@@ -237,8 +237,7 @@ AnomalyDetectionVec = function(x, max_anoms=0.10, direction='pos', alpha=0.05, p
       lines_at <- seq(1, length(all_data[[2]]), period)+min(all_data[[1]])
       xgraph <- ggplot2::ggplot(all_data, ggplot2::aes_string(x="timestamp", y="count")) + ggplot2::theme_bw() + ggplot2::theme(panel.grid.major = ggplot2::element_blank(), panel.grid.minor = ggplot2::element_blank(), text=ggplot2::element_text(size = 14))
       xgraph <- xgraph + ggplot2::geom_line(data=x_subset_previous, ggplot2::aes_string(colour=color_name), alpha=alpha*.33) + ggplot2::geom_line(data=x_subset_single_period, ggplot2::aes_string(color=color_name), alpha=alpha)    
-      yrange <- get_range(all_data, index=2)
-      xgraph <- xgraph + add_formatted_y(yrange)
+      yrange <- get_range(all_data, index=2, y_log=y_log)
       xgraph <- xgraph + ggplot2::scale_x_continuous(breaks=lines_at, expand=c(0,0))
       xgraph <- xgraph + ggplot2::geom_vline(xintercept=lines_at, color="gray60")
       xgraph <- xgraph + ggplot2::labs(x=xlabel, y=ylabel, title=plot_title)    
@@ -255,8 +254,7 @@ AnomalyDetectionVec = function(x, max_anoms=0.10, direction='pos', alpha=0.05, p
       }
       xgraph <- ggplot2::ggplot(x, ggplot2::aes_string(x="timestamp", y="count")) + ggplot2::theme_bw() + ggplot2::theme(panel.grid.major = ggplot2::element_blank(), panel.grid.minor = ggplot2::element_blank(), text=ggplot2::element_text(size = 14))
       xgraph <- xgraph + ggplot2::geom_line(data=x, ggplot2::aes_string(colour=color_name), alpha=alpha)
-      yrange <- get_range(x, index=2)
-      xgraph <- xgraph + add_formatted_y(yrange)
+      yrange <- get_range(x, index=2, y_log=y_log)
       xgraph <- xgraph + ggplot2::scale_x_continuous(breaks=lines_at, expand=c(0,0))
       xgraph <- xgraph + ggplot2::geom_vline(xintercept=lines_at, color="gray60")
       xgraph <- xgraph + ggplot2::labs(x=xlabel, y=ylabel, title=plot_title)
@@ -270,10 +268,7 @@ AnomalyDetectionVec = function(x, max_anoms=0.10, direction='pos', alpha=0.05, p
     xgraph <- xgraph + ggplot2::theme(axis.text.x=ggplot2::element_blank()) + ggplot2::theme(legend.position="none") 
     
     # Use log scaling if set by user
-    if (y_log) {
-      # print("scaling y axis to log")
-      xgraph <- xgraph + ggplot2::coord_trans(ytrans = "log10")
-    }
+    xgraph <- xgraph + add_formatted_y(yrange, y_log=y_log)
   }
   
   # Store expected values if set by user


### PR DESCRIPTION
Issue #9. 
Put the y log transformation into the add_formatted_y function rather than as its own line to prevent overwriting the y-axis formatting.
I also had to add some logic into get_range so that it can set an appropriate (i.e. >0) minimum when y_log is being used, hope that's okay.