### PR TITLE
When plot = FALSE, don't call plot.new

### DIFF
--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -297,7 +297,7 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
   # If there are no anoms, then let's exit
   if(anom_pct == 0){
     if(verbose) message("No anomalies detected.")
-    return (list("anoms"=data.frame(), "plot"=plot.new()))
+    return (list("anoms"=data.frame(), "plot"=NULL))
   }
 
   if(plot){
@@ -359,6 +359,6 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
   if(plot){
     return (list(anoms = anoms, plot = xgraph))
   } else {
-    return (list(anoms = anoms, plot = plot.new()))
+    return (list(anoms = anoms, plot = NULL))
   }
 }

--- a/R/vec_anom_detection.R
+++ b/R/vec_anom_detection.R
@@ -224,7 +224,7 @@ AnomalyDetectionVec = function(x, max_anoms=0.10, direction='pos',
   # If there are no anoms, then let's exit
   if(anom_pct == 0){
     if(verbose) message("No anomalies detected.")
-    return (list("anoms"=data.frame(), "plot"=plot.new()))
+    return (list("anoms"=data.frame(), "plot"=NULL))
   }
   
   if(plot){
@@ -287,6 +287,6 @@ AnomalyDetectionVec = function(x, max_anoms=0.10, direction='pos',
   if(plot){
     return (list(anoms = anoms, plot = xgraph))
   } else {
-    return (list(anoms = anoms, plot = plot.new()))
+    return (list(anoms = anoms, plot = NULL))
   }
 }


### PR DESCRIPTION
plot.new() is generally unfriendly to call unless it will actually be
used for drawing, and certainly not if we ask for no plots to be
created.

plot.new triggers the completion of the previous plotting action, and as
such can't be used in combination with any multithreading or forked R
processes.

plot.new also does not return a "plot" object, it always returns `NULL`,
so although it appears to be used here as a way of returning a "null
plot", all that really happens is that AnomalyDetection\* returns
`list(..., plot = NULL)`.

This commit resolves #60
