### PR TITLE
Millisecond granularity fixes

### DIFF
--- a/R/detect_anoms.R
+++ b/R/detect_anoms.R
@@ -87,7 +87,7 @@ detect_anoms <- function(data, k = 0.49, alpha = 0.05, num_obs_per_period = NULL
 
         # protect against constant time series
         data_sigma <- func_sigma(data[[2L]])
-        if(data_sigma == 0) 
+        if(is.na(data_sigma) || data_sigma == 0) 
             break
 
         ares <- ares/data_sigma

--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -166,11 +166,15 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
     x <- format_timestamp(aggregate(x[2], format(x[1], "%Y-%m-%d %H:%M:00"), eval(parse(text="sum"))))
   }
 
+  ## This is a bit tricky, since the number of samples really isn't guaranteed to be 1 measurement per whatever the 'gran' variable says it is.
+  ## Either we'll need to do something smarter (look at the delta between the first and the last timestamp and count the number of rows) or
+  ## alternatively, simply make 'period' a function argument and use these values as defaults.
   period = switch(gran,
                   min = 1440,
+                  ms = 1000,
+                  sec = 60*60,
                   hr = 24,
-                  # if the data is daily, then we need to bump the period to weekly to get multiple examples
-                  day = 7)
+                  day = 7) # if the data is daily, then we need to bump the period to weekly to get multiple examples
   num_obs <- length(x[[2]])
 
   if(max_anoms < 1/num_obs){

--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -162,7 +162,7 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
   }
 
   # Aggregate data to minutely if secondly
-  if(gran == "sec"){
+  if(gran == "sec" || gran == "ms"){
     x <- format_timestamp(aggregate(x[2], format(x[1], "%Y-%m-%d %H:%M:00"), eval(parse(text="sum"))))
   }
 


### PR DESCRIPTION
Our system produces data with millisecond precision, from disparate monitoring systems, every 5 minutes. AnomalyDetectionTs() does not really handle data like that properly as-is. The code that tries to figure out what period to use simply hasn't implemented the 'ms' granularity case (nor has it the 'sec' granularity case), and the formatting that is applies in the 'sec' granularity case is never applied to millisecond-precision data making the code blow up on it.

This branch fixes those two problems, though I would suggest rethinking how to detect the 'period' parameter as well (see individual commits for further comments)
