### PR TITLE
Fixes/for upstream

### DIFF
--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -166,11 +166,15 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
     x <- format_timestamp(aggregate(x[2], format(x[1], "%Y-%m-%d %H:%M:00"), eval(parse(text="sum"))))
   }
 
+  ## This is a bit tricky, since the number of samples really isn't guaranteed to be 1 measurement per whatever the 'gran' variable says it is.
+  ## Either we'll need to do something smarter (look at the delta between the first and the last timestamp and count the number of rows) or
+  ## alternatively, simply make 'period' a function argument and use these values as defaults.
   period = switch(gran,
                   min = 1440,
+                  ms = 1000,
+                  sec = 60*60,
                   hr = 24,
-                  # if the data is daily, then we need to bump the period to weekly to get multiple examples
-                  day = 7)
+                  day = 7) # if the data is daily, then we need to bump the period to weekly to get multiple examples
   num_obs <- length(x[[2]])
 
   if(max_anoms < 1/num_obs){

--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -162,7 +162,7 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
   }
 
   # Aggregate data to minutely if secondly
-  if(gran == "sec"){
+  if(gran == "sec" || gran == "ms"){
     x <- format_timestamp(aggregate(x[2], format(x[1], "%Y-%m-%d %H:%M:00"), eval(parse(text="sum"))))
   }
 


### PR DESCRIPTION
This is a renewed pull request for the 'millisecond' precision  fixes.

I added a fix for the delta_sigma bug to the previous  branch but it appears somebody else beat me to it, here: https://github.com/twitter/AnomalyDetection/pull/59 .  I don't have anything to add to this, so in order to not pollute the branch I'm leaving it out.

This pull request contains two commits, each one dealing with the fact that the data we're using uses ms precision, but contains measurements that come in every 5 minutes - from a set of monitoring stations, so they come in in bunches. 

Granularity detection assumes that if you have 'X' precision your data also contains one measurement per X, but that is clearly not always the case, as the above testcase demonstrates. Worse, the code doesn't even deal with the possibility that the  granularity detection might say "ms". The switch in question simply doesn't handle it, causing the code to blow up with an error. Ditto for seconds.

The basic "it blows up" thing is easily fixed, but the deeper issue of handling measurement intervals that are disparate from the measurement's precision is not. That requires a rethink of the code.
