### PR TITLE
Change double quotes to single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ anomalies that occurred during the last day or last hour. Execute the following
 command:
 
 ```
-res = AnomalyDetectionTs(raw_data, max_anoms=0.02, direction='both', only_last=”day”, plot=TRUE)
+res = AnomalyDetectionTs(raw_data, max_anoms=0.02, direction='both', only_last='day', plot=TRUE)
 res$plot
 ```
 


### PR DESCRIPTION
Fix unexpected input error by changing double quotes to single quotes. Here's what I ran:

```
library(AnomalyDetection)
data(raw_data)
res = AnomalyDetectionTs(raw_data, max_anoms=0.02, direction='both', only_last=”day”, plot=TRUE)
```

And here's the error I received:

```
Error: unexpected input in "res = AnomalyDetectionTs(raw_data, max_anoms=0.02, direction='both', only_last=�"
```
