### PR TITLE
Possible fix for #77

### DIFF
--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -164,6 +164,7 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
   # Aggregate data to minutely if secondly
   if(gran == "sec"){
     x <- format_timestamp(aggregate(x[2], format(x[1], "%Y-%m-%d %H:%M:00"), eval(parse(text="sum"))))
+    gran <- "min"
   }
 
   period = switch(gran,


### PR DESCRIPTION
> after granulation from sec to min, assign 'min' so the switch instruction can now work properly

This fixes cases when we have time series with granulation in seconds, tested on R version 3.3.1